### PR TITLE
Update docker config

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,2 @@
+# UDATA web exposed port
+UDATA_HTTP_EXPOSED=7000

--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,8 @@
 # UDATA web exposed port
 UDATA_HTTP_EXPOSED=7000
+
+# UDATA Redis exposed port
+UDATA_REDIS_EXPOSED=6379
+
+# UDATA MongoDB exposed port
+UDATA_MONGODB_EXPOSED=27017

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/docker-compose.override.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+/.env
 /docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   mongodb:
     image: mongo:6.0.4
+    networks:
+      - udata
     volumes:
       - mongo-data:/data/db
     ports:
@@ -8,6 +10,8 @@ services:
 
   redis:
     image: redis
+    networks:
+      - udata
     volumes:
       - redis-data:/data
     ports:
@@ -15,9 +19,11 @@ services:
 
   udata:
     build: .
-    links:
-      - mongodb:mongodb
-      - redis:redis
+    depends_on:
+      - mongodb
+      - redis
+    networks:
+      - udata
     command: serve --host 0.0.0.0 --debugger --reload
     environment:
       - FLASK_DEBUG=true
@@ -25,6 +31,9 @@ services:
       - udata-fs:/udata/fs
     ports:
       - "${UDATA_HTTP_EXPOSED:-7000}:7000"
+
+networks:
+  udata:
 
 volumes:
   udata-fs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,14 @@ services:
     volumes:
       - mongo-data:/data/db
     ports:
-      - "27017:27017"
+      - "${UDATA_MONGODB_EXPOSED:-27017}:27017"
 
   redis:
     image: redis
     volumes:
       - redis-data:/data
     ports:
-    - "6379:6379"
+    - "${UDATA_REDIS_EXPOSED:-6379}:6379"
 
   udata:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   mongodb:
     image: mongo:6.0.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - udata-fs:/udata/fs
     ports:
-      - "7000:7000"
+      - "${UDATA_HTTP_EXPOSED:-7000}:7000"
 
 volumes:
   udata-fs:


### PR DESCRIPTION
Little updates and improvements for docker compose config
- Fix: links are not supported (legacy for docker official, and not supported by podman). Replacing by common network + depends_on
- Fix: version is obsolete: => remove version as this is no longer used by docker compose
- Feat: replace static exposed port values for services by env vars + default values in docker compose file allowing overriding them via .env file
- Add: .env.template file as model of env variables to customize exposed (UDATA_HTTP|REDIS|MONGODB|_EXPOSED_PORT) port in docker compose config. just copy this file to .env
- Add: .gitignore to ignore:
    - .env: override env vars for docker-compose, can contains local and sensitive data wihtout being tracked by git
    - docker-compose.override.yml: override docker-compose config by local specific values/attributes wihtout being tracked by git